### PR TITLE
Add multilingual support for the reconnect button

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 
 - ✨ **Auto-Reconnect**: Instantly restores Ring camera live view when disconnected
 - 🔒 **Privacy First**: No data collection, works 100% locally
+- 🌍 **Multilingual**: Supports reconnection in multiple languages including English, German, Spanish and more
 - 🚀 **Zero Configuration**: Works immediately after installation
 - 🎯 **Lightweight**: Minimal system resource usage
 - 🌐 **Browser Support**: Works on both Chrome and Firefox
@@ -182,6 +183,12 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 Please ensure your code follows the existing style and includes appropriate comments.
 
 ## Changelog
+
+### Version 1.1.2 (2025-03-20)
+- Added multilingual support for the reconnect button
+- Now supports German, Spanish, French, Italian, Dutch and several other languages
+- Improved button detection for non-English Ring interfaces
+- Enhanced logging to show which language was detected
 
 ### Version 1.1.1 (2025-02-21)
 - Removed unnecessary activeTab permission for better privacy

--- a/src/shared/content.js
+++ b/src/shared/content.js
@@ -125,11 +125,28 @@ function initialize() {
                 }
             }
 
-            // Method 2: Backup - look for any button containing "Reconnect" text
+            // Method 2: Backup - look for any button with reconnect text in various languages
+            const reconnectTexts = [
+                'Reconnect',                    // English
+                'Verbindung wiederherstellen',  // German
+                'Reconectar',                   // Spanish
+                'Reconnecter',                  // French
+                'Riconnetti',                   // Italian
+                'Opnieuw verbinden',            // Dutch
+                'Yeniden bağlan',               // Turkish
+                'Připojit znovu',               // Czech
+                'Połącz ponownie',              // Polish
+                'Переподключиться',             // Russian
+                'Újracsatlakozás',              // Hungarian
+                '重新连接',                      // Chinese (Simplified)
+                '再接続'                         // Japanese
+            ];
+            
             const allButtons = document.querySelectorAll('button');
             for (const button of allButtons) {
-                if (button.textContent.includes('Reconnect')) {
-                    debugLog('Found and clicking reconnect button (backup method)...', true);
+                const buttonText = button.textContent.trim();
+                if (reconnectTexts.some(text => buttonText.includes(text))) {
+                    debugLog(`Found and clicking reconnect button with text "${buttonText}" (backup method)...`, true);
                     button.click();
                     showReconnectNotification();
                     return true;


### PR DESCRIPTION
- Added multilingual support for the reconnect button
- Now supports German, Spanish, French, Italian, Dutch and several other languages
- Improved button detection for non-English Ring interfaces
- Enhanced logging to show which language was detected
